### PR TITLE
tf.compat.v1 added to support TF1.x in latest TF

### DIFF
--- a/deep500/frameworks/tensorflow/custom_operators/tf.py
+++ b/deep500/frameworks/tensorflow/custom_operators/tf.py
@@ -1,6 +1,8 @@
 import ctypes
 import os
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 from tensorflow.python.framework import ops
 import numpy as np
 from typing import List, Union, Type, Dict

--- a/deep500/frameworks/tensorflow/op_validation.py
+++ b/deep500/frameworks/tensorflow/op_validation.py
@@ -1,7 +1,9 @@
 from typing import List, Any
 
 import numpy as np
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from deep500.lv0.validation.metrics import DefaultOpMetrics
 from deep500.utils.metrics import TestMetric

--- a/deep500/frameworks/tensorflow/tf_distributed_optimizer.py
+++ b/deep500/frameworks/tensorflow/tf_distributed_optimizer.py
@@ -1,7 +1,9 @@
 from deep500.frameworks.tensorflow.tf_optimizers import TFOptimizer
 from deep500.lv3.communication import CommunicationNetwork
 
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 class HorovodDistributedOptimizer(TFOptimizer):
     def __init__(self, optimizer: TFOptimizer, comm=None):

--- a/deep500/frameworks/tensorflow/tf_graph_executor.py
+++ b/deep500/frameworks/tensorflow/tf_graph_executor.py
@@ -4,7 +4,9 @@ import numpy as np
 
 import deep500 as d5
 
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 from .tf_network import TensorflowNetwork
 from .tf_visitor_impl import TensorflowVisitor

--- a/deep500/frameworks/tensorflow/tf_network.py
+++ b/deep500/frameworks/tensorflow/tf_network.py
@@ -2,8 +2,9 @@ from typing import List
 
 import deep500 as d5
 
-
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 
 class TensorflowNetwork(d5.Network):

--- a/deep500/frameworks/tensorflow/tf_optimizers.py
+++ b/deep500/frameworks/tensorflow/tf_optimizers.py
@@ -1,4 +1,7 @@
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 from typing import Union
 
 from deep500.lv2.optimizer import FirstOrderOptimizer

--- a/deep500/frameworks/tensorflow/tf_visitor_impl.py
+++ b/deep500/frameworks/tensorflow/tf_visitor_impl.py
@@ -2,7 +2,9 @@ import itertools
 from functools import partial
 
 import numpy as np
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 
 import deep500 as d5
 

--- a/samples/deepbench/conv_overhead_tensorflow.py
+++ b/samples/deepbench/conv_overhead_tensorflow.py
@@ -1,5 +1,7 @@
 import time
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import deepbench
 
 AVG_OVER = 10

--- a/samples/deepbench/gemm_overhead_tensorflow.py
+++ b/samples/deepbench/gemm_overhead_tensorflow.py
@@ -1,5 +1,7 @@
 import time
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import deepbench
 
 AVG_OVER = 10

--- a/samples/tf_native_operator.py
+++ b/samples/tf_native_operator.py
@@ -1,7 +1,9 @@
 # Validates a native TensorFlow operator (here tf.matmul) using a Deep500 
 # Operator.
 import numpy as np
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 from deep500.frameworks import tensorflow as d5tf
 
 from deep500.frameworks import reference as d5ref

--- a/samples/tf_native_training.py
+++ b/samples/tf_native_training.py
@@ -1,6 +1,8 @@
 # Trains a native TensorFlow model using a Deep500 executor and a native 
 # optimizer.
-import tensorflow as tf
+# Compatiable tf version for v1
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
 import numpy as np
 
 import deep500 as d5


### PR DESCRIPTION
To run the deep500 in the latest TF 2.x version. I added tf.compat.v1 in the code. I tested it on TF 2.8.0